### PR TITLE
Allow for `aws-sdk` credentials from other sources

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,12 +9,11 @@ var fs = require('fs');
 
 function S3Zipper(awsConfig) {
     assert.ok(awsConfig, 'AWS S3 options must be defined.');
-    assert.notEqual(awsConfig.accessKeyId, undefined, 'Requires S3 AWS Key.');
-    assert.notEqual(awsConfig.secretAccessKey, undefined, 'Requires S3 AWS Secret');
     assert.notEqual(awsConfig.region, undefined, 'Requires AWS S3 region.');
     assert.notEqual(awsConfig.bucket, undefined, 'Requires AWS S3 bucket.');
     this.init(awsConfig);
 }
+
 S3Zipper.prototype = {
     init: function (awsConfig) {
         this.awsConfig = awsConfig;


### PR DESCRIPTION
Allow for use of EC2 roles and other `aws-sdk` credentials by removing checks for `awsConfig` key and secret. See the [aws-sdk guide](https://docs.aws.amazon.com/AWSJavaScriptSDK/guide/node-configuring.html) for more info.

I will comment here once I have a chance to test it but it should work fine.
